### PR TITLE
Displaying error markers at all graphical elements

### DIFF
--- a/web/src/app/modules/forms/modules/validation/services/validation.service.ts
+++ b/web/src/app/modules/forms/modules/validation/services/validation.service.ts
@@ -43,6 +43,13 @@ export class ValidationService {
         return this.isValid(this.navigator.currentElement, this.navigator.currentContents);
     }
 
+    public get currentInvalidElements(): IContainer[] {
+        return this.validate(this.navigator.currentElement, this.navigator.currentContents)
+            .filter((result: ValidationResult) => !result.isValid)
+            .map((result: ValidationResult) => result.elements)
+            .reduce((prev: IContainer[], cur: IContainer[]) => prev.concat(cur), []);
+    }
+
     public allValid(contents: IContainer[]): boolean {
         if (!contents) {
             return true;

--- a/web/src/app/modules/forms/modules/validation/services/validation.service.ts
+++ b/web/src/app/modules/forms/modules/validation/services/validation.service.ts
@@ -36,7 +36,9 @@ export class ValidationService {
     public isValid(element: IContainer, contents: IContainer[] = []): boolean {
         const validationResults: ValidationResult[] = this.validate(element, contents);
         const isValid: boolean = !validationResults.some((validationResult: ValidationResult) => !validationResult.isValid);
-        return isValid;
+        const currentInvalidContainsElement: boolean =
+            this.currentInvalidElements.find((otherElement: IContainer) => otherElement === element) !== undefined;
+        return isValid && !currentInvalidContainsElement;
     }
 
     public get currentValid(): boolean {

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-decision-graphical-node.component.svg
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-decision-graphical-node.component.svg
@@ -3,6 +3,7 @@
     [attr.x]="x" 
     [attr.y]="y" 
     [ngClass]="{'selected': selected, 'deselected': !selected, 'invalid': !isValid, 'valid': isValid}" />
+<svg:text *ngIf="isVisible && !isValid" [attr.x]="center.x" [attr.y]="center.y" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
 <svg:rect *ngIf="isVisible"
     [attr.x]="dragDummyPosition.x" [attr.y]="dragDummyPosition.y" (mouseover)="drag($event)" (mousemove)="drag($event)" (mouseleave)="leave($event)" (mousedown)="grab($event)" (mouseup)="drop($event)"
     [attr.width]="dragDummyDimensions.width + 2" 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-end-graphical-node.component.svg
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-end-graphical-node.component.svg
@@ -10,6 +10,7 @@
     [attr.cy]="center.y"
     [attr.r]="radius"
     [ngClass]="{'outerSelected': selected, 'outerDeselected': !selected, 'invalid': !isValid, 'valid': isValid}" />
+<svg:text *ngIf="isVisible && !isValid" [attr.x]="center.x" [attr.y]="center.y" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
 <svg:rect *ngIf="isVisible"
     [attr.x]="dragDummyPosition.x" [attr.y]="dragDummyPosition.y" (mouseover)="drag($event)" (mousemove)="drag($event)" (mouseleave)="leave($event)" (mousedown)="grab($event)" (mouseup)="drop($event)"
     [attr.width]="dragDummyDimensions.width + 2" 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-end-graphical-node.component.svg
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-end-graphical-node.component.svg
@@ -10,7 +10,7 @@
     [attr.cy]="center.y"
     [attr.r]="radius"
     [ngClass]="{'outerSelected': selected, 'outerDeselected': !selected, 'invalid': !isValid, 'valid': isValid}" />
-<svg:text *ngIf="isVisible && !isValid" [attr.x]="center.x" [attr.y]="center.y" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
+<svg:text *ngIf="isVisible && !isValid" [attr.x]="center.x + radius + 3" [attr.y]="center.y" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
 <svg:rect *ngIf="isVisible"
     [attr.x]="dragDummyPosition.x" [attr.y]="dragDummyPosition.y" (mouseover)="drag($event)" (mousemove)="drag($event)" (mouseleave)="leave($event)" (mousedown)="grab($event)" (mouseup)="drop($event)"
     [attr.width]="dragDummyDimensions.width + 2" 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-start-graphical-node.component.svg
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-start-graphical-node.component.svg
@@ -4,6 +4,7 @@
     [attr.cy]="center.y"
     [attr.r]="radius"
     [ngClass]="{'selected': selected, 'deselected': !selected, 'invalid': !isValid, 'valid': isValid}" />
+<svg:text *ngIf="isVisible && !isValid" [attr.x]="center.x" [attr.y]="center.y" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
 <svg:rect *ngIf="isVisible"
     [attr.x]="dragDummyPosition.x" [attr.y]="dragDummyPosition.y" (mouseover)="drag($event)" (mousemove)="drag($event)" (mouseleave)="leave($event)" (mousedown)="grab($event)" (mouseup)="drop($event)"
     [attr.width]="dragDummyDimensions.width + 2" 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-start-graphical-node.component.svg
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-start-graphical-node.component.svg
@@ -4,7 +4,7 @@
     [attr.cy]="center.y"
     [attr.r]="radius"
     [ngClass]="{'selected': selected, 'deselected': !selected, 'invalid': !isValid, 'valid': isValid}" />
-<svg:text *ngIf="isVisible && !isValid" [attr.x]="center.x" [attr.y]="center.y" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
+<svg:text *ngIf="isVisible && !isValid" [attr.x]="center.x + radius + 3" [attr.y]="center.y" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
 <svg:rect *ngIf="isVisible"
     [attr.x]="dragDummyPosition.x" [attr.y]="dragDummyPosition.y" (mouseover)="drag($event)" (mousemove)="drag($event)" (mouseleave)="leave($event)" (mousedown)="grab($event)" (mouseup)="drop($event)"
     [attr.width]="dragDummyDimensions.width + 2" 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-step-graphical-node.component.svg
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/process/process-step-graphical-node.component.svg
@@ -10,7 +10,7 @@
         [ngClass]="{'selected': selected, 'deselected': !selected, 'invalid': !isValid, 'valid': isValid}">
     </svg:rect>
     <svg:g truncated-text [text]="title" [width]="dimensions.width" [position]="{x: dimensions.width / 2.0, y: (0.5 * ((dimensions.height / 2) - 1) + 15)}"></svg:g>
-    <svg:text *ngIf="!isValid" [attr.x]="dimensions.width - 20" [attr.y]="(1 * ((dimensions.height / 3) - 1) + 15)" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
+    <svg:text *ngIf="isVisible && !isValid" [attr.x]="dimensions.width - 20" [attr.y]="(1 * ((dimensions.height / 3) - 1) + 15)" style="font-family: FontAwesome; fill:#d9534f;">&#xf071;</svg:text>
 </svg:svg>
 <svg:rect *ngIf="isVisible"
     [attr.x]="dragDummyPosition.x" [attr.y]="dragDummyPosition.y" (mouseover)="drag($event)" (mousemove)="drag($event)" (mouseleave)="leave($event)" (mousedown)="grab($event)" (mouseup)="drop($event)"

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/elements/graphical-element-base.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/elements/graphical-element-base.ts
@@ -18,6 +18,7 @@ export abstract class GraphicalElementBase<T extends IContainer> {
     }
 
     public get isValid(): boolean {
-        return this.validationService.isValid(this.element);
+        return this.validationService.isValid(this.element) &&
+            this.validationService.currentInvalidElements.find((element: IContainer) => element === this.element) === undefined;
     }
 }

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/elements/graphical-element-base.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/elements/graphical-element-base.ts
@@ -18,7 +18,6 @@ export abstract class GraphicalElementBase<T extends IContainer> {
     }
 
     public get isValid(): boolean {
-        return this.validationService.isValid(this.element) &&
-            this.validationService.currentInvalidElements.find((element: IContainer) => element === this.element) === undefined;
+        return this.validationService.isValid(this.element);
     }
 }

--- a/web/src/app/validation/process/missing-condition-validator.ts
+++ b/web/src/app/validation/process/missing-condition-validator.ts
@@ -29,12 +29,13 @@ export class MissingConditionValidator extends ElementValidatorBase<Process> {
         let decisionConnections: ProcessConnection[] =
             processConnections.filter((connection: ProcessConnection) =>
                 decisionNodes.find((node: ProcessDecision) => node.url === connection.source.url) !== undefined);
-        let hasMissingConditions: boolean =
-            decisionConnections.find((connection: ProcessConnection) =>
-                connection.condition === undefined || connection.condition === null || connection.condition === '') !== undefined;
 
-        if (hasMissingConditions) {
-            return new ValidationResult(Config.ERROR_MISSING_CONDITION, false, []);
+        let invalidElements: IContainer[] =
+            decisionConnections.filter((connection: ProcessConnection) =>
+                connection.condition === undefined || connection.condition === null || connection.condition === '');
+
+        if (invalidElements.length > 0) {
+            return new ValidationResult(Config.ERROR_MISSING_CONDITION, false, invalidElements);
         }
         return ValidationResult.VALID;
     }


### PR DESCRIPTION
See https://trello.com/c/zplaQ5gm/156-process-model-bei-start-ende-und-decision-fehlt-das-rote-ausrufezeichen-im-symbol-wenn-das-feld-name-leer-ist

We wanted to have error markers at all nodes and edges in the edited graphs.
