### PR TITLE
Set common controls color to white.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ hs_err_pid*
 /web/dist
 bundles/specmate-std-env/workspace/.metadata/.log
 bundles/specmate-ui-core/webcontent/COMMITHASH
+/cnf/bin/

--- a/web/src/app/modules/actions/modules/common-controls/components/common-controls.component.html
+++ b/web/src/app/modules/actions/modules/common-controls/components/common-controls.component.html
@@ -1,7 +1,7 @@
 <form *ngIf="isEnabled && connected" class="form-inline">
-    <div class="btn btn-primary btn-sm" title="{{'save' | translate}}" [ngClass]="{'disabled': !isSaveEnabled}" (click)="save()"><i class="fa fa-save" aria-hidden="true"></i></div>&nbsp;
-    <div class="btn btn-warning btn-sm" title="{{'undo' | translate}}" [ngClass]="{'disabled': !isUndoEnabled}" (click)="undo()"><i class="fa fa-undo" aria-hidden="true"></i></div>&nbsp;
-    <div class="btn btn-danger btn-sm" title="{{'navigate.back' | translate}}" [ngClass]="{'disabled': !isBackEnabled}" (click)="back()"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i></div>&nbsp;
-    <div class="btn btn-danger btn-sm" title="{{'navigate.forward' | translate}}" [ngClass]="{'disabled': !isForwardEnabled}" (click)="forward()"><i class="fa fa-arrow-circle-right" aria-hidden="true"></i></div>&nbsp;
+    <div class="btn btn-secondary btn-sm" title="{{'save' | translate}}" [ngClass]="{'disabled': !isSaveEnabled}" (click)="save()"><i class="fa fa-save" aria-hidden="true"></i></div>&nbsp;
+    <div class="btn btn-secondary btn-sm" title="{{'undo' | translate}}" [ngClass]="{'disabled': !isUndoEnabled}" (click)="undo()"><i class="fa fa-undo" aria-hidden="true"></i></div>&nbsp;
+    <div class="btn btn-secondary btn-sm" title="{{'navigate.back' | translate}}" [ngClass]="{'disabled': !isBackEnabled}" (click)="back()"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i></div>&nbsp;
+    <div class="btn btn-secondary btn-sm" title="{{'navigate.forward' | translate}}" [ngClass]="{'disabled': !isForwardEnabled}" (click)="forward()"><i class="fa fa-arrow-circle-right" aria-hidden="true"></i></div>&nbsp;
 </form>
 <div *ngIf="!connected" class="btn btn-outline-danger btn-sm" title="{{'connection.lost' | translate}}"><i aria-hidden="true" class="fa fa-exclamation-triangle"></i>&nbsp;{{'connection.lost' | translate}}</div>


### PR DESCRIPTION
To be consistent with our usabillity standards all common controls buttons should have the same color scheme.