### PR TITLE
Remove useless variable 'index'

### DIFF
--- a/web/src/app/modules/data/modules/data-service/services/data-cache.ts
+++ b/web/src/app/modules/data/modules/data-service/services/data-cache.ts
@@ -102,7 +102,7 @@ export class DataCache {
             this.contentsStore[parentUrl] = [];
         }
         let parentContents = this.getParentContents(element.url);
-        let index: number = parentContents.indexOf(element);
+
         if (parentContents.indexOf(element) < 0) {
             parentContents.push(element);
             // Leads to serious performance issues in the project explorer when expanding a node with many (1000s) children.

--- a/web/src/app/modules/data/modules/data-service/services/scheduler.ts
+++ b/web/src/app/modules/data/modules/data-service/services/scheduler.ts
@@ -46,7 +46,7 @@ export class Scheduler {
         if (!lastCommand) {
             return undefined;
         }
-        let compoundId: string = lastCommand.compoundId;
+        
         let unresolvedCompoundCommands: Command[] =
             this.unresolvedCommands.filter((command: Command) => command.compoundId === lastCommand.compoundId);
         for (let i = unresolvedCompoundCommands.length - 1; i >= 0; i--) {


### PR DESCRIPTION
This is a code smell.
The variable 'index' is created in function 'addToParentContent',  but its value is never read. So here we decide to remove it.

Group 2