### PR TITLE
Remove useless variable [el, target, source]

### DIFF
--- a/web/src/app/modules/views/main/editors/base/draggable-supporting-view-base.ts
+++ b/web/src/app/modules/views/main/editors/base/draggable-supporting-view-base.ts
@@ -47,7 +47,7 @@ export abstract class DraggableSupportingViewBase extends SpecmateViewBase {
     }
 
     private onDropModel(value: any): void {
-        let [el, target, source] = value;
+    
         this.sanitizeContentPositions(true);
     }
 


### PR DESCRIPTION
The variable [el, target, source] is declared in function onDropModel. This variable is never be read, so we decided to remove it.

Group 2