### PR TITLE
Remove this unnecessary cast.

### DIFF
--- a/web/src/app/modules/navigation/modules/navigator/services/navigator.service.ts
+++ b/web/src/app/modules/navigation/modules/navigator/services/navigator.service.ts
@@ -105,7 +105,7 @@ export class NavigatorService {
             await this.navigateDefault();
             return;
         }
-        const element = target as IContainer;
+        const element = target;
         if (this.history[this.current] !== element) {
             this.history.splice(this.current + 1, 0, element);
             this.performNavigation(this.current + 1).then(() => {


### PR DESCRIPTION
The TypeScript compiler automatically casts a variable to the relevent type inside conditionals. So it is unnecessary to make casts and not-null assertions. Here we remove this unnecessary cast.
Group 1
