### PR TITLE
Refactor this function so that its implementation doesn't duplicate t…

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-row.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-row.component.ts
@@ -89,11 +89,15 @@ export class TestCaseRow {
     }
 
     public get outputParameters(): TestParameter[] {
-        if (!this.testParameters) {
-            return undefined;
-        }
-        let parameters: TestParameter[] = this.testParameters.filter((element: TestParameter) => element.type === 'OUTPUT');
-        return parameters;
+         return this.getInOutParameters('OUTPUT');
+    }
+
+    private getInOutParameters(type: string): TestParameter[] {
+         if (!this.testParameters) {
+         return undefined;
+    }
+         let parameters: TestParameter[] = this.testParameters.filter((element: TestParameter) => element.type === type);
+         return parameters;
     }
 
     private get assignments(): ParameterAssignment[] {

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-row.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-row.component.ts
@@ -81,11 +81,7 @@ export class TestCaseRow {
     }
 
     public get inputParameters(): TestParameter[] {
-        if (!this.testParameters) {
-            return undefined;
-        }
-        let parameters: TestParameter[] = this.testParameters.filter((element: TestParameter) => element.type === 'INPUT');
-        return parameters;
+        return this.getInOutParameters('INPUT');
     }
 
     public get outputParameters(): TestParameter[] {


### PR DESCRIPTION
…he one on line 83

Because InputParameters and OutputParameters have the same implementation, so I create getInOutParameters to return outParameters to call. The functions that we change are inputParameters and outputParameters functions in Test-case-row. We have manually test the functions and it can work as before.
Group 1