### PR TITLE
Added generic font-family

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/common/connection-line.component.css
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/common/connection-line.component.css
@@ -17,7 +17,7 @@
 }
 
 .warning {
-    font-family: FontAwesome;
+    font-family: FontAwesome, sans-serif;
     fill: #d9534f;
 }
 


### PR DESCRIPTION
### What we did?
Added sans-serif as failover font family to the class warning

### Why we did it?
As per specmate and other documentation online, it is recommended to have a generic font family, in case the browser couldn't load the first font family "FontAwesome", so in case the browser couldn't load the "FontAwesome" then it will use "sans-serif" and it will not let the browser to decide its default.

Group 6