### PR TITLE
Change tab order of editor buttons to left-to-right

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
@@ -1,13 +1,15 @@
 <div *ngIf="contents" class="card maximized">
     <h5 class="card-header">{{name}}
-        <maximize-button></maximize-button>
-        <!-- GRID -->
-        <button  *ngIf="!isGridShown" (click)="showGrid()" class="btn btn-sm btn-secondary pull-right" title="{{'showGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
-        <button  *ngIf="isGridShown" (click)="hideGrid()" class="btn btn-sm btn-secondary pull-right" title="{{'hideGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
-        <!-- ZOOM -->
-        <button id="editor-zoomin-button" (click)="zoomIn()" class="btn btn-sm btn-secondary pull-right" [class.disabled]="!canZoomIn" title="{{'zoomIn' | translate}}"><i class="fa fa-search-plus" aria-hidden="true"></i></button>
-        <button (click)="resetZoom()" class="btn btn-sm btn-secondary pull-right zoom-indicator" title="{{'restoreZoom' | translate}}">{{zoom * 100 | number: '1.0-0'}}%</button>
-        <button id="editor-zoomout-button" (click)="zoomOut()" class="btn btn-sm btn-secondary pull-right" [class.disabled]="!canZoomOut" title="{{'zoomOut' | translate}}"><i class="fa fa-search-minus" aria-hidden="true"></i></button>
+        <div class="pull-right">
+            <!-- ZOOM -->
+            <button id="editor-zoomout-button" (click)="zoomOut()" class="btn btn-sm btn-secondary pull-left" [class.disabled]="!canZoomOut" title="{{'zoomOut' | translate}}"><i class="fa fa-search-minus" aria-hidden="true"></i></button>
+            <button (click)="resetZoom()" class="btn btn-sm btn-secondary pull-left zoom-indicator" title="{{'restoreZoom' | translate}}">{{zoom * 100 | number: '1.0-0'}}%</button>
+            <button id="editor-zoomin-button" (click)="zoomIn()" class="btn btn-sm btn-secondary pull-left" [class.disabled]="!canZoomIn" title="{{'zoomIn' | translate}}"><i class="fa fa-search-plus" aria-hidden="true"></i></button>
+            <!-- GRID -->
+            <button  *ngIf="!isGridShown" (click)="showGrid()" class="btn btn-sm btn-secondary pull-left" title="{{'showGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
+            <button  *ngIf="isGridShown" (click)="hideGrid()" class="btn btn-sm btn-secondary pull-left" title="{{'hideGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
+            <maximize-button></maximize-button>
+        </div>
     </h5>
     <div class="card-body">
         <tool-pallette></tool-pallette>

--- a/web/src/app/modules/views/main/editors/modules/maximize-button/components/maximize-button.component.html
+++ b/web/src/app/modules/views/main/editors/modules/maximize-button/components/maximize-button.component.html
@@ -1,2 +1,2 @@
-<button *ngIf="!isMaximized" (click)="maximize()" class="btn btn-sm btn-secondary pull-right" title="{{'maximize' | translate}}"><i class="fa fa-window-maximize" aria-hidden="true"></i></button>
-<button *ngIf="isMaximized" (click)="unmaximize()" class="btn btn-sm btn-secondary pull-right" title="{{'restoreWindow' | translate}}"><i class="fa fa-window-restore" aria-hidden="true"></i></button>
+<button *ngIf="!isMaximized" (click)="maximize()" class="btn btn-sm btn-secondary pull-left" title="{{'maximize' | translate}}"><i class="fa fa-window-maximize" aria-hidden="true"></i></button>
+<button *ngIf="isMaximized" (click)="unmaximize()" class="btn btn-sm btn-secondary pull-left" title="{{'restoreWindow' | translate}}"><i class="fa fa-window-restore" aria-hidden="true"></i></button>


### PR DESCRIPTION
- Feature number 12 in the list (group 8)
- This patch changed the tab order of the editor buttons to
  left-to-right