### PR TITLE
Removed duplication of "confirmDelete" function on line 18

### DIFF
--- a/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
+++ b/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
@@ -27,7 +27,7 @@ export class ConfirmationModal {
         return modalRef.result;
     }
 
-    public openOkCancel(title: string, message: string): Promise<any> {
+    public confirmDelete(title: string, message: string): Promise<any> {
         const modalRef = this.modalService.open(TypedModalContent);
         modalRef.componentInstance.options = Dialogtype.okCancelDialog(title, message);
         return modalRef.result;
@@ -35,7 +35,7 @@ export class ConfirmationModal {
 
     public confirmSave(message?: string): Promise<void> {
         if (this.dataService.hasCommits) {
-            return this.openOkCancel('ConfirmationRequired', message || this.translate.instant('confirmSave'));
+            return this.confirmDelete('ConfirmationRequired', message || this.translate.instant('confirmSave'));
         }
         return Promise.resolve();
     }


### PR DESCRIPTION
A function "openOkcancel" is duplicating the functionalities of "confirmDelete" . So, we refactored this code so that the implementation is not duplicated. On line 38 the call  is being returned to "confirmDelete".