### PR TITLE
the code has been refactored so that the return value actually refers to "_testSpecifications"

### DIFF
--- a/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
+++ b/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
@@ -27,7 +27,7 @@ export class ConfirmationModal {
         return modalRef.result;
     }
 
-    public openOkCancel(title: string, message: string): Promise<any> {
+    public confirmDelete(title: string, message: string): Promise<any> {
         const modalRef = this.modalService.open(TypedModalContent);
         modalRef.componentInstance.options = Dialogtype.okCancelDialog(title, message);
         return modalRef.result;
@@ -35,7 +35,7 @@ export class ConfirmationModal {
 
     public confirmSave(message?: string): Promise<void> {
         if (this.dataService.hasCommits) {
-            return this.openOkCancel('ConfirmationRequired', message || this.translate.instant('confirmSave'));
+            return this.confirmDelete('ConfirmationRequired', message || this.translate.instant('confirmSave'));
         }
         return Promise.resolve();
     }

--- a/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
+++ b/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
@@ -34,3 +34,4 @@ export class ConfirmationModal {
         return Promise.resolve();
     }
 }
+

--- a/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
+++ b/web/src/app/modules/notification/modules/modals/services/confirmation-modal.service.ts
@@ -26,13 +26,7 @@ export class ConfirmationModal {
         modalRef.componentInstance.options = Dialogtype.okDialog(title, message);
         return modalRef.result;
     }
-
-    public confirmDelete(title: string, message: string): Promise<any> {
-        const modalRef = this.modalService.open(TypedModalContent);
-        modalRef.componentInstance.options = Dialogtype.okCancelDialog(title, message);
-        return modalRef.result;
-    }
-
+  
     public confirmSave(message?: string): Promise<void> {
         if (this.dataService.hasCommits) {
             return this.confirmDelete('ConfirmationRequired', message || this.translate.instant('confirmSave'));

--- a/web/src/app/modules/views/side/modules/links-actions/components/links-actions.component.ts
+++ b/web/src/app/modules/views/side/modules/links-actions/components/links-actions.component.ts
@@ -20,6 +20,12 @@ export class LinksActions {
     public _model: IContainer;
     public _contents: IContainer[];
     public _testSpecifications: TestSpecification[];
+    private _additionalInformationservice: TestSpecification;
+    public get additionalInformationService_1(): TestSpecification {
+           return this._additionalInformationalService;
+    }
+    public set additionlInformationService_1(value: TestSpecification) {
+           this._additionalInformationService = value;  
     public descriptionVisible: boolean;
 
     constructor(private additionalInformationService: AdditionalInformationService) { }


### PR DESCRIPTION
The property "_testSpecifications" is not being returned to the class that is being called from.The getter is referring to another class in the code segment which is resulting in a code smell. The code has been refactored so that the return value actually refers to "_testSpecifications"
