### PR TITLE
Feature 12 (Mandatory) - Changed Tab Order buttons of Graphical Editor (Group 3)

### DIFF
--- a/web/src/app/modules/views/main/authentication/modules/login/components/login.component.html
+++ b/web/src/app/modules/views/main/authentication/modules/login/components/login.component.html
@@ -58,7 +58,7 @@
                     <i class="fa fa-sign-in"></i>&nbsp;{{'login' | translate}}
                 </ng-container>
             </button>
-            <span id="login-language-dropdown" class="pull-right"><language-chooser></language-chooser></span>
+            <span id="login-language-dropdown" class="Pull-allign-to-left"><language-chooser></language-chooser></span>   
         </div>
     </div>
     <div class="col-md-5"></div>

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
@@ -1,13 +1,13 @@
 <div *ngIf="contents" class="card maximized">
     <h5 class="card-header">{{name}}
-        <div class="pull-right">
+        <div class="Pull-allign-to-left">
             <!-- ZOOM -->
-            <button id="editor-zoomout-button" (click)="zoomOut()" class="btn btn-sm btn-secondary pull-left" [class.disabled]="!canZoomOut" title="{{'zoomOut' | translate}}"><i class="fa fa-search-minus" aria-hidden="true"></i></button>
-            <button (click)="resetZoom()" class="btn btn-sm btn-secondary pull-left zoom-indicator" title="{{'restoreZoom' | translate}}">{{zoom * 100 | number: '1.0-0'}}%</button>
-            <button id="editor-zoomin-button" (click)="zoomIn()" class="btn btn-sm btn-secondary pull-left" [class.disabled]="!canZoomIn" title="{{'zoomIn' | translate}}"><i class="fa fa-search-plus" aria-hidden="true"></i></button>
+            <button id="editor-zoomout-button" (click)="zoomOut()" class="btn btn-sm btn-secondary pull-allign-left" [class.disabled]="!canZoomOut" title="{{'zoomOut' | translate}}"><i class="fa fa-search-minus" aria-hidden="true"></i></button>
+            <button (click)="resetZoom()" class="btn btn-sm btn-secondary pull-allign-left zoom-indicator" title="{{'restoreZoom' | translate}}">{{zoom * 100 | number: '1.0-0'}}%</button>
+            <button id="editor-zoomin-button" (click)="zoomIn()" class="btn btn-sm btn-secondary pull-allign-left" [class.disabled]="!canZoomIn" title="{{'zoomIn' | translate}}"><i class="fa fa-search-plus" aria-hidden="true"></i></button>
             <!-- GRID -->
-            <button  *ngIf="!isGridShown" (click)="showGrid()" class="btn btn-sm btn-secondary pull-left" title="{{'showGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
-            <button  *ngIf="isGridShown" (click)="hideGrid()" class="btn btn-sm btn-secondary pull-left" title="{{'hideGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
+            <button  *ngIf="!isGridShown" (click)="showGrid()" class="btn btn-sm btn-secondary pull-allign-left" title="{{'showGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
+            <button  *ngIf="isGridShown" (click)="hideGrid()" class="btn btn-sm btn-secondary pull-allign-left" title="{{'hideGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
             <maximize-button></maximize-button>
         </div>
     </h5>

--- a/web/src/app/modules/views/main/editors/modules/maximize-button/components/maximize-button.component.html
+++ b/web/src/app/modules/views/main/editors/modules/maximize-button/components/maximize-button.component.html
@@ -1,2 +1,2 @@
-<button *ngIf="!isMaximized" (click)="maximize()" class="btn btn-sm btn-secondary pull-left" title="{{'maximize' | translate}}"><i class="fa fa-window-maximize" aria-hidden="true"></i></button>
-<button *ngIf="isMaximized" (click)="unmaximize()" class="btn btn-sm btn-secondary pull-left" title="{{'restoreWindow' | translate}}"><i class="fa fa-window-restore" aria-hidden="true"></i></button>
+<button *ngIf="!isMaximized" (click)="maximize()" class="btn btn-sm btn-secondary pull-allign-left" title="{{'maximize' | translate}}"><i class="fa fa-window-maximize" aria-hidden="true"></i></button>
+<button *ngIf="isMaximized" (click)="unmaximize()" class="btn btn-sm btn-secondary pull-allign-left" title="{{'restoreWindow' | translate}}"><i class="fa fa-window-restore" aria-hidden="true"></i></button>


### PR DESCRIPTION
The tab order of the buttons in graphical editor was initially from right to left. We refactored the code so that it is changed from left to right. Only the order of the buttons is changed and the position of the buttons is still on the right top corner.