### PR TITLE
Persistency needs more time to startup on Travis

### DIFF
--- a/bundles/specmate-migration-test/src/com/specmate/migration/test/MigrationTestBase.java
+++ b/bundles/specmate-migration-test/src/com/specmate/migration/test/MigrationTestBase.java
@@ -217,7 +217,7 @@ public abstract class MigrationTestBase {
 		persistencyTracker.open();
 		IPersistencyService persistency;
 		try {
-			persistency = persistencyTracker.waitForService(10000);
+			persistency = persistencyTracker.waitForService(20000);
 		} catch (InterruptedException e) {
 			throw new SpecmateException(e);
 		}


### PR DESCRIPTION
This fixes the current test failures. The net4j exceptions in the migration tests are not nice but don't affect the tests. I'm not sure what causes them and how they can be fixed.