### PR TITLE
Selecting model as fallback

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
@@ -16,7 +16,7 @@
     </div>
 
     <div class="editor" tabindex="0" (scroll)="onScroll($event)" #editorElement>
-        <svg:svg (click)="click($event)"  (mousedown)="mousedown($event)" (mouseup)="mouseup($event)"  (mouseleave)="mouseleave($event)" (mousemove)="mousemove($event)" (mouseover)="mousemove($event)" [attr.width]="editorDimensions.width * zoom" [attr.height]="editorDimensions.height * zoom" [style.cursor]="cursor">
+        <svg:svg (click)="click($event)" (mousedown)="mousedown($event)" (mouseup)="mouseup($event)"  (mouseleave)="mouseleave($event)" (mousemove)="mousemove($event)" (mouseover)="mousemove($event)" [attr.width]="editorDimensions.width * zoom" [attr.height]="editorDimensions.height * zoom" [style.cursor]="cursor">
             <svg:g [attr.transform]="'scale(' + zoom + ')'">
 
                 <!-- GRID -->

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -289,6 +289,9 @@ export class GraphicalEditor {
                 this.editorToolsService.activateDefaultTool();
             }
         }
+        if (!this.selectedElementService.hasSelection) {
+            this.selectedElementService.select(this.model);
+        }
     }
 
     private select(element: IContainer, event: MouseEvent): void {


### PR DESCRIPTION
When you click on the grid in the model editors, nothing was selected anymore (and the right sidebar dissapeared). Instead, the model should be selected.