### PR TITLE
Rotate colors in project explorer tabs

### DIFF
--- a/web/src/assets/scss/specmate.extensions.scss
+++ b/web/src/assets/scss/specmate.extensions.scss
@@ -165,3 +165,11 @@ textarea:focus,
     height: 100vh;
     padding-top: 64px;
 }
+
+.nav-tabs .nav-link {
+    color: #495057;
+}
+
+.nav-tabs .nav-link.active {
+    color: #007ea8;
+}


### PR DESCRIPTION
We had the request to change the colors in the project explorer tab, so that the active tab is blue and the inactive tab is grey.