### PR TITLE
Ignoring changes, where an undefined field becomes an empty string

### DIFF
--- a/web/src/app/modules/forms/modules/generic-form/components/generic-form.component.ts
+++ b/web/src/app/modules/forms/modules/generic-form/components/generic-form.component.ts
@@ -142,7 +142,8 @@ export class GenericForm {
                 updateValue = converter.convertFromControlToModel(updateValue);
             }
             // We do not need to clone here (hopefully), because only simple values can be passed via forms.
-            if (this.element[fieldName] + '' !== updateValue + '') {
+            const originalValue = this.element[fieldName] || '';
+            if (originalValue !== updateValue + '') {
                 this.element[fieldName] = updateValue;
                 changed = true;
             }


### PR DESCRIPTION
See: https://trello.com/c/5HT21CSi/313-unn%C3%B6tige-popups-bei-geister%C3%A4nderungen

Behavior:
- Reload Specmate
- Open a library folder
- Open another library folder
- Unsaved-changes modal is displayed (but there are no changes, actually)

Desired Behavior: No changes modal is displayed

This PR realizes the desired behavior.