### PR TITLE
Returning values from generic service calls.

### DIFF
--- a/web/src/app/modules/data/modules/data-service/services/service-interface.ts
+++ b/web/src/app/modules/data/modules/data-service/services/service-interface.ts
@@ -71,8 +71,8 @@ export class ServiceInterface {
         await this.http.delete(Url.urlDelete(url), { headers: this.getAuthHeader(token) }).toPromise();
     }
 
-    public async performOperation(url: string, serviceSuffix: string, payload: any, token: UserToken): Promise<void> {
-        await this.http.post(Url.urlCustomService(url, serviceSuffix), payload, { headers: this.getAuthHeader(token) }).toPromise();
+    public async performOperation(url: string, serviceSuffix: string, payload: any, token: UserToken): Promise<any> {
+        return await this.http.post(Url.urlCustomService(url, serviceSuffix), payload, { headers: this.getAuthHeader(token) }).toPromise();
     }
 
     public async performQuery(url: string, serviceSuffix: string, parameters: { [key: string]: string }, token: UserToken): Promise<any> {

--- a/web/src/app/modules/data/modules/data-service/services/specmate-data.service.ts
+++ b/web/src/app/modules/data/modules/data-service/services/specmate-data.service.ts
@@ -314,9 +314,9 @@ export class SpecmateDataService {
         }).catch((error) => this.handleError(this.translate.instant('elementCouldNotBeDeleted'), url, error));
     }
 
-    public performOperations(url: string, operation: string, payload?: any): Promise<void> {
+    public performOperations(url: string, operation: string, payload?: any): Promise<any> {
         if (!this.auth.isAuthenticatedForUrl(url)) {
-            return Promise.resolve();
+            return Promise.resolve(false);
         }
         this.busy = true;
         return this.serviceInterface.performOperation(url, operation, payload, this.auth.token).then((result) => {


### PR DESCRIPTION
The service calls `performOperations` and `performOperation` did not return values needed in `ExportTestprocedureButton`-component (line 45). I changed the calls to return the correpsonding values. 