### PR TITLE
Catching all exceptions in connectors

### DIFF
--- a/bundles/specmate-connectors/src/com/specmate/connectors/internal/ConnectorTask.java
+++ b/bundles/specmate-connectors/src/com/specmate/connectors/internal/ConnectorTask.java
@@ -73,7 +73,7 @@ public class ConnectorTask extends SchedulerTask {
 					});
 
 				}
-			} catch (SpecmateException e) {
+			} catch (Exception e) {
 				logService.log(LogService.LOG_ERROR, e.getMessage());
 				transaction.rollback();
 			}


### PR DESCRIPTION
This should fix the issue that the connector service crashes, when something bad happens in the connectors.