### PR TITLE
Fix CSV Export

### DIFF
--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/BaseSkeleton.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/BaseSkeleton.java
@@ -32,7 +32,7 @@ public abstract class BaseSkeleton {
 	}
 
 	private static int compareParameter(TestParameter p1, TestParameter p2) {
-		return p1.getType().compareTo(p2.getType()) * 10 + p1.getName().compareTo(p2.getName());
+		return p1.getType().compareTo(p2.getType()) * 10 + Integer.signum(p1.getName().compareTo(p2.getName()));
 	}
 
 	public TestSpecificationSkeleton generate(TestSpecification testSpecification) {

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/CSVTestSpecificationSkeleton.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/CSVTestSpecificationSkeleton.java
@@ -25,7 +25,7 @@ public class CSVTestSpecificationSkeleton extends BaseSkeleton {
 		StringJoiner joiner = new StringJoiner(COL_SEP);
 		joiner.add("\"TC\"");
 		for (TestParameter param : parameters) {
-			joiner.add(StringUtils.wrap(param.getName(), TEXT_WRAP));
+			joiner.add(StringUtils.wrap(param.getType().toString() + " - " + param.getName(), TEXT_WRAP));
 		}
 		sb.append(joiner).append("\n");
 	}

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/CSVTestSpecificationSkeleton.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/CSVTestSpecificationSkeleton.java
@@ -49,7 +49,9 @@ public class CSVTestSpecificationSkeleton extends BaseSkeleton {
 	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments) {
 		StringJoiner joiner = new StringJoiner(COL_SEP);
 		for (ParameterAssignment assignment : assignments) {
-			joiner.add(StringUtils.wrap(assignment.getValue(), TEXT_WRAP));
+			String assignmentValue = assignment.getValue();
+			String characterToEscape = "=";
+			joiner.add(StringUtils.wrap(escapeString(assignmentValue, characterToEscape) + assignmentValue, TEXT_WRAP));
 		}
 		sb.append(joiner.toString());
 	}
@@ -57,6 +59,11 @@ public class CSVTestSpecificationSkeleton extends BaseSkeleton {
 	@Override
 	protected String generateFileName(TestSpecification testSpecification) {
 		return replaceInvalidChars(testSpecification.getName()) + ".csv";
+	}
+	
+	protected String escapeString(String stringToCheck, String characterToEscape) {
+		String escapeCharacter = (stringToCheck.substring(0, 1).equals(characterToEscape)) ? "'" : "";
+		return escapeCharacter;
 	}
 
 }


### PR DESCRIPTION
see comments here https://trello.com/c/bjJ5wuKV/349-csv-export-reihenfolge-von-spaltennamen-und-spalteninhalten-passt-nicht-zusammen-v-0215

correct sorting of input and output columns
add input/output bedore column name