### PR TITLE
fix: manually changing testspecification is not reflected in export

### DIFF
--- a/bundles/specmate-testspecification/.classpath
+++ b/bundles/specmate-testspecification/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>

--- a/bundles/specmate-testspecification/bnd.bnd
+++ b/bundles/specmate-testspecification/bnd.bnd
@@ -18,7 +18,8 @@
 	specmate-emfrest-api;version=latest,\
 	specmate-rest;version=latest,\
 	org.apache.commons.lang3;version=3.5,\
-	org.eclipse.equinox.common
+	org.eclipse.equinox.common,\
+	org.eclipse.net4j.util
 Private-Package: \
 	com.specmate.testspecification.internal.services,\
 	com.specmate.testspecification.internal.testskeleton

--- a/bundles/specmate-testspecification/bnd.bnd
+++ b/bundles/specmate-testspecification/bnd.bnd
@@ -1,4 +1,5 @@
 -buildpath: \
+	org.apache.servicemix.bundles.junit;version=4.12,\
 	specmate-model-gen;version=latest,\
 	specmate-common;version=latest,\
 	org.eclipse.emf.cdo,\
@@ -16,7 +17,8 @@
 	org.sat4j.pb,\
 	specmate-emfrest-api;version=latest,\
 	specmate-rest;version=latest,\
-	org.apache.commons.lang3;version=3.5
+	org.apache.commons.lang3;version=3.5,\
+	org.eclipse.equinox.common
 Private-Package: \
 	com.specmate.testspecification.internal.services,\
 	com.specmate.testspecification.internal.testskeleton

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/BaseSkeleton.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/BaseSkeleton.java
@@ -39,7 +39,7 @@ public abstract class BaseSkeleton {
 		StringBuilder sb = new StringBuilder();
 
 		TestSpecificationSkeleton tss = TestspecificationFactory.eINSTANCE.createTestSpecificationSkeleton();
-		tss.setLanguage(this.language);
+		tss.setLanguage(language);
 		tss.setName(generateFileName(testSpecification));
 
 		List<TestParameter> parameters = getParameters(testSpecification);
@@ -62,29 +62,29 @@ public abstract class BaseSkeleton {
 	 */
 	private List<ParameterAssignment> getTestCaseParameterAssignments(TestCase tc) {
 		return SpecmateEcoreUtil.pickInstancesOf(tc.getContents(), ParameterAssignment.class).stream()
-				.sorted(this.assignmentComparator).collect(Collectors.toList());
+				.sorted(assignmentComparator).collect(Collectors.toList());
 	}
 
 	/** Return Test parameters sorted by type (input before output) */
 	private List<TestParameter> getParameters(TestSpecification testSpecification) {
 		return SpecmateEcoreUtil.pickInstancesOf(testSpecification.getContents(), TestParameter.class).stream()
-				.sorted(this.parameterComparator).collect(Collectors.toList());
+				.sorted(parameterComparator).collect(Collectors.toList());
 	}
 
 	private List<TestCase> getTestCases(TestSpecification testSpecification) {
 		return SpecmateEcoreUtil.pickInstancesOf(testSpecification.getContents(), TestCase.class);
 	}
 
-	protected String replaceInvalidChars(String r) {
-		r = startsNumerical.matcher(r).replaceAll("");
-		return invalidChars.matcher(r).replaceAll("_");
+	protected String replaceInvalidChars(String name) {
+		name = startsNumerical.matcher(name).replaceAll("");
+		return invalidChars.matcher(name).replaceAll("_");
 	}
 
 	protected void appendParameterValue(StringBuilder sb, ParameterAssignment pa) {
 		sb.append("___");
 		sb.append(replaceInvalidChars(pa.getParameter().getName()));
 		sb.append("__");
-		sb.append(replaceInvalidChars(pa.getValue()));
+		sb.append(replaceInvalidChars(pa.getCondition()));
 	}
 
 	protected void appendDateComment(StringBuilder sb) {

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/CSVTestSpecificationSkeleton.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/CSVTestSpecificationSkeleton.java
@@ -49,7 +49,7 @@ public class CSVTestSpecificationSkeleton extends BaseSkeleton {
 	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments) {
 		StringJoiner joiner = new StringJoiner(COL_SEP);
 		for (ParameterAssignment assignment : assignments) {
-			String assignmentValue = assignment.getValue();
+			String assignmentValue = assignment.getCondition();
 			String characterToEscape = "=";
 			joiner.add(StringUtils.wrap(escapeString(assignmentValue, characterToEscape) + assignmentValue, TEXT_WRAP));
 		}
@@ -60,7 +60,7 @@ public class CSVTestSpecificationSkeleton extends BaseSkeleton {
 	protected String generateFileName(TestSpecification testSpecification) {
 		return replaceInvalidChars(testSpecification.getName()) + ".csv";
 	}
-	
+
 	protected String escapeString(String stringToCheck, String characterToEscape) {
 		String escapeCharacter = (stringToCheck.substring(0, 1).equals(characterToEscape)) ? "'" : "";
 		return escapeCharacter;

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/JavaTestSpecificationSkeleton.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/testskeleton/JavaTestSpecificationSkeleton.java
@@ -19,7 +19,11 @@ public class JavaTestSpecificationSkeleton extends BaseSkeleton {
 	}
 
 	private String getClassName(TestSpecification testSpecification) {
-		return replaceInvalidChars(testSpecification.getName()) + "Test";
+		String tsName = testSpecification.getName();
+		if (tsName == null) {
+			tsName = "";
+		}
+		return replaceInvalidChars(tsName) + "Test";
 	}
 
 	@Override

--- a/bundles/specmate-testspecification/test/com/specmate/testspecification/test/TestSkeletonTest.java
+++ b/bundles/specmate-testspecification/test/com/specmate/testspecification/test/TestSkeletonTest.java
@@ -1,0 +1,102 @@
+package com.specmate.testspecification.test;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.specmate.model.testspecification.ParameterAssignment;
+import com.specmate.model.testspecification.ParameterType;
+import com.specmate.model.testspecification.TestCase;
+import com.specmate.model.testspecification.TestParameter;
+import com.specmate.model.testspecification.TestSpecification;
+import com.specmate.model.testspecification.TestSpecificationSkeleton;
+import com.specmate.model.testspecification.TestspecificationFactory;
+import com.specmate.testspecification.internal.testskeleton.JavaTestSpecificationSkeleton;
+
+public class TestSkeletonTest {
+	@Test
+	public void testJavaSkeleton() {
+		TestSpecification ts = getTestSpecification();
+
+		JavaTestSpecificationSkeleton skel = new JavaTestSpecificationSkeleton("JAVA");
+		TestSpecificationSkeleton result = skel.generate(ts);
+		String code = result.getCode();
+
+		Assert.assertTrue(code.contains("public void TSTest___in1__in11___in2__in12___out1__out11___out2__out12()"));
+		Assert.assertTrue(code.contains("public void TSTest___in1__in21___in2__in22___out1__out21___out2__out22()"));
+	}
+
+	private TestSpecification getTestSpecification() {
+		TestspecificationFactory f = TestspecificationFactory.eINSTANCE;
+		TestSpecification ts = f.createTestSpecification();
+		ts.setName("TS");
+
+		TestParameter input1 = f.createTestParameter();
+		input1.setId("in1");
+		input1.setName("in1");
+		input1.setType(ParameterType.INPUT);
+
+		TestParameter input2 = f.createTestParameter();
+		input2.setId("in2");
+		input2.setName("in2");
+		input2.setType(ParameterType.INPUT);
+
+		TestParameter output1 = f.createTestParameter();
+		output1.setId("out1");
+		output1.setName("out1");
+		output1.setType(ParameterType.OUTPUT);
+
+		TestParameter output2 = f.createTestParameter();
+		output2.setId("out2");
+		output2.setName("out2");
+		output2.setType(ParameterType.OUTPUT);
+
+		ts.getContents().addAll(Arrays.asList(input1, input2, output1, output2));
+
+		TestCase tc1 = f.createTestCase();
+		tc1.setId("tc1");
+		tc1.setName("tc1");
+
+		ParameterAssignment assIn11 = f.createParameterAssignment();
+		assIn11.setParameter(input1);
+		assIn11.setValue("in11");
+
+		ParameterAssignment assIn12 = f.createParameterAssignment();
+		assIn12.setParameter(input2);
+		assIn12.setValue("in12");
+
+		ParameterAssignment assOut11 = f.createParameterAssignment();
+		assOut11.setParameter(output1);
+		assOut11.setValue("out11");
+
+		ParameterAssignment assOut12 = f.createParameterAssignment();
+		assOut12.setParameter(output2);
+		assOut12.setValue("out12");
+		tc1.getContents().addAll(Arrays.asList(assIn11, assIn12, assOut11, assOut12));
+
+		TestCase tc2 = f.createTestCase();
+		tc2.setId("tc2");
+		tc2.setName("tc2");
+
+		ParameterAssignment assIn21 = f.createParameterAssignment();
+		assIn21.setParameter(input1);
+		assIn21.setValue("in21");
+
+		ParameterAssignment assIn22 = f.createParameterAssignment();
+		assIn22.setParameter(input2);
+		assIn22.setValue("in22");
+
+		ParameterAssignment assOut21 = f.createParameterAssignment();
+		assOut21.setParameter(output1);
+		assOut21.setValue("out21");
+
+		ParameterAssignment assOut22 = f.createParameterAssignment();
+		assOut22.setParameter(output2);
+		assOut22.setValue("out22");
+		tc2.getContents().addAll(Arrays.asList(assIn21, assIn22, assOut21, assOut22));
+
+		ts.getContents().addAll(Arrays.asList(tc1, tc2));
+		return ts;
+	}
+}

--- a/bundles/specmate-testspecification/test/com/specmate/testspecification/test/TestSkeletonTest.java
+++ b/bundles/specmate-testspecification/test/com/specmate/testspecification/test/TestSkeletonTest.java
@@ -61,18 +61,22 @@ public class TestSkeletonTest {
 		ParameterAssignment assIn11 = f.createParameterAssignment();
 		assIn11.setParameter(input1);
 		assIn11.setValue("in11");
+		assIn11.setCondition("in11");
 
 		ParameterAssignment assIn12 = f.createParameterAssignment();
 		assIn12.setParameter(input2);
 		assIn12.setValue("in12");
+		assIn12.setCondition("in12");
 
 		ParameterAssignment assOut11 = f.createParameterAssignment();
 		assOut11.setParameter(output1);
 		assOut11.setValue("out11");
+		assOut11.setCondition("out11");
 
 		ParameterAssignment assOut12 = f.createParameterAssignment();
 		assOut12.setParameter(output2);
 		assOut12.setValue("out12");
+		assOut12.setCondition("out12");
 		tc1.getContents().addAll(Arrays.asList(assIn11, assIn12, assOut11, assOut12));
 
 		TestCase tc2 = f.createTestCase();
@@ -82,18 +86,22 @@ public class TestSkeletonTest {
 		ParameterAssignment assIn21 = f.createParameterAssignment();
 		assIn21.setParameter(input1);
 		assIn21.setValue("in21");
+		assIn21.setCondition("in21");
 
 		ParameterAssignment assIn22 = f.createParameterAssignment();
 		assIn22.setParameter(input2);
 		assIn22.setValue("in22");
+		assIn22.setCondition("in22");
 
 		ParameterAssignment assOut21 = f.createParameterAssignment();
 		assOut21.setParameter(output1);
 		assOut21.setValue("out21");
+		assOut21.setCondition("out21");
 
 		ParameterAssignment assOut22 = f.createParameterAssignment();
 		assOut22.setParameter(output2);
 		assOut22.setValue("out22");
+		assOut22.setCondition("out22");
 		tc2.getContents().addAll(Arrays.asList(assIn21, assIn22, assOut21, assOut22));
 
 		ts.getContents().addAll(Arrays.asList(tc1, tc2));


### PR DESCRIPTION
Fixes the following problem:

1) Create a new test specification
2) Manualle edit the test specification and save it
3) Result: Edit is not reflected in export