### PR TITLE
Enabling save button sometimes

### DIFF
--- a/web/src/app/modules/actions/modules/common-controls/components/common-controls.component.ts
+++ b/web/src/app/modules/actions/modules/common-controls/components/common-controls.component.ts
@@ -5,6 +5,7 @@ import { UISafe } from '../../../../common/modules/ui/ui-safe-decorator';
 import { SpecmateDataService } from '../../../../data/modules/data-service/services/specmate-data.service';
 import { ValidationService } from '../../../../forms/modules/validation/services/validation.service';
 import { NavigatorService } from '../../../../navigation/modules/navigator/services/navigator.service';
+import { ValidationErrorSeverity } from '../../../../../validation/validation-error-severity';
 
 @Component({
     moduleId: module.id.toString(),
@@ -60,7 +61,9 @@ export class CommonControls {
     }
 
     public get isSaveEnabled(): boolean {
-        return this.isEnabled && this.hasCommits && this.validator.currentValid;
+        const hasSaveDisablingError =
+            this.validator.currentSeverities.find(severity => severity === ValidationErrorSeverity.SAVE_DISABLED) !== undefined;
+        return this.isEnabled && this.hasCommits && !hasSaveDisablingError;
     }
 
     public get isUndoEnabled(): boolean {

--- a/web/src/app/modules/forms/modules/validation/services/validation.service.ts
+++ b/web/src/app/modules/forms/modules/validation/services/validation.service.ts
@@ -11,6 +11,8 @@ import { SpecmateDataService } from '../../../../data/modules/data-service/servi
 import { NavigatorService } from '../../../../navigation/modules/navigator/services/navigator.service';
 import { ValidationCache } from '../util/validation-cache';
 import { ValidNameValidator } from '../../../../../validation/valid-name-validator';
+import { ValidationErrorSeverity } from '../../../../../validation/validation-error-severity';
+import { TextLengthValidator } from '../../../../../validation/text-length-validator';
 
 @Injectable()
 export class ValidationService {
@@ -18,6 +20,7 @@ export class ValidationService {
     private static DISABLED_CHILD_VALIDATION_TYPES: { className: string }[] = [Folder];
     private validationCache: ValidationCache;
     private validNameValidator: ValidNameValidator = new ValidNameValidator();
+    private textLengthValidator: TextLengthValidator = new TextLengthValidator();
 
     constructor(private navigator: NavigatorService, private dataService: SpecmateDataService) {
         this.validationCache = new ValidationCache();
@@ -46,11 +49,13 @@ export class ValidationService {
         }
         const requiredFieldsResults: ValidationResult = this.getRequiredFieldsValidator(element).validate(element);
         const validNameResult: ValidationResult = this.validNameValidator.validate(element);
+        const textLengthValidationResult: ValidationResult = this.textLengthValidator.validate(element);
         const elementValidators = this.getElementValidators(element) || [];
         let elementResults: ValidationResult[] =
             elementValidators.map((validator: ElementValidatorBase<IContainer>) => validator.validate(element, contents))
                              .concat(requiredFieldsResults)
-                             .concat(validNameResult);
+                             .concat(validNameResult)
+                             .concat(textLengthValidationResult);
 
         this.validationCache.addEntriesToCache(element.url, contURLs, elementResults);
         return elementResults;
@@ -76,6 +81,11 @@ export class ValidationService {
             .find(disabledType => Type.is(currentElement, disabledType)) !== undefined;
         const contents = ignoreContents ? [] : this.navigator.currentContents;
         return this.isValid(this.navigator.currentElement, contents);
+    }
+
+    public get currentSeverities(): ValidationErrorSeverity[] {
+        return this.validate(this.navigator.currentElement, this.navigator.currentContents)
+            .map(validationResult => validationResult.severity);
     }
 
     public get currentInvalidElements(): IContainer[] {

--- a/web/src/app/validation/text-length-validator.ts
+++ b/web/src/app/validation/text-length-validator.ts
@@ -1,0 +1,22 @@
+import { ElementValidatorBase } from './element-validator-base';
+import { IContainer } from '../model/IContainer';
+import { ValidationResult } from './validation-result';
+import { ValidationErrorSeverity } from './validation-error-severity';
+
+export class TextLengthValidator extends ElementValidatorBase<IContainer> {
+    public validate(element: IContainer, contents?: IContainer[]): ValidationResult {
+        const keys = Object.keys(element);
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            const currentAttribute = element[key];
+            if (typeof currentAttribute === 'string') {
+                if (currentAttribute.length >= 4000) {
+                    return new ValidationResult('errorTextTooLong',
+                        false, [element], ValidationErrorSeverity.SAVE_DISABLED);
+                }
+            }
+        }
+        return ValidationResult.VALID;
+    }
+
+}

--- a/web/src/app/validation/valid-name-validator.ts
+++ b/web/src/app/validation/valid-name-validator.ts
@@ -3,6 +3,7 @@ import { MetaInfo } from '../model/meta/field-meta';
 import { ElementValidatorBase } from './element-validator-base';
 import { ValidationResult } from './validation-result';
 import { ValidationMessage } from './validation-message';
+import { ValidationErrorSeverity } from './validation-error-severity';
 
 export class ValidNameValidator extends ElementValidatorBase<IContainer> {
 
@@ -20,7 +21,7 @@ export class ValidNameValidator extends ElementValidatorBase<IContainer> {
         }
         if (!element.name.match(validName)) {
             let message = ValidationMessage.ERROR_INVALID_NAME;
-            return new ValidationResult(message, false, [element]);
+            return new ValidationResult(message, false, [element], ValidationErrorSeverity.SAVE_DISABLED);
         }
         return ValidationResult.VALID;
     }

--- a/web/src/app/validation/validation-error-severity.ts
+++ b/web/src/app/validation/validation-error-severity.ts
@@ -1,0 +1,3 @@
+export enum ValidationErrorSeverity {
+    SAVE_DISABLED, SAVE_ENABLED, IGNORE
+}

--- a/web/src/app/validation/validation-result.ts
+++ b/web/src/app/validation/validation-result.ts
@@ -1,14 +1,17 @@
 import { IContainer } from '../model/IContainer';
 import { ValidationMessage } from './validation-message';
+import { ValidationErrorSeverity } from './validation-error-severity';
 
 export class ValidationResult {
     public message: ValidationMessage;
-    constructor(message: string|ValidationMessage, public isValid: boolean, public elements: IContainer[]) {
+    constructor(message: string|ValidationMessage,
+        public isValid: boolean, public elements: IContainer[],
+            public severity: ValidationErrorSeverity = ValidationErrorSeverity.SAVE_ENABLED) {
         if (typeof message === 'string') {
             this.message = new ValidationMessage(message);
         } else {
             this.message = message;
         }
     }
-    public static VALID: ValidationResult = new ValidationResult('', true, []);
+    public static VALID: ValidationResult = new ValidationResult('', true, [], ValidationErrorSeverity.IGNORE);
 }

--- a/web/src/assets/i18n/de.json
+++ b/web/src/assets/i18n/de.json
@@ -229,6 +229,7 @@
 		"errorProcessNodeMultipleOutgoingConnections": "Nicht-Entscheidungsknoten mit mehreren ausgehenden Verbindungen.",
 		"errorProcessStartIncomingConnection": "Startknoten mit eingehenden Verbindungen.",
 		"errorSingleIndegreeNode": "Knoten hat nur eine Ursache und ist somit überflüssig.",
+		"errorTextTooLong": "Eine Eigenschagft des Objekts enthält Text, der zu lang ist.",
 		"errorUnconnectedNode": "Unverbundener Knoten im Model."
 	},
 	"version": "Version",

--- a/web/src/assets/i18n/gb.json
+++ b/web/src/assets/i18n/gb.json
@@ -228,6 +228,7 @@
 		"errorProcessNodeMultipleOutgoingConnections": "Non-decision-node with multiple outgoing connections.",
 		"errorProcessStartIncomingConnection": "Start node with incoming connection.",
 		"errorSingleIndegreeNode": "Node has only one cause and is therefore unnecessary.",
+		"errorTextTooLong": "A text property of the element is too long.",
 		"errorUnconnectedNode": "Unconnected node in model."
 	},
 	"version": "Version",


### PR DESCRIPTION
This enables the save button on invalid models. But the save button is not enabled if:
- there is a string field that is longer than 4000 chars
- there is a name field that contains forbidden chars.