### PR TITLE
Undo option for deleting the search input

### DIFF
--- a/web/src/app/modules/navigation/modules/project-explorer/components/project-explorer.component.css
+++ b/web/src/app/modules/navigation/modules/project-explorer/components/project-explorer.component.css
@@ -2,9 +2,3 @@ ul {
     padding: 0 0 0 10px;
     width: 100%;
 }
-
-.fa-remove {
-    border: none;
-    border-bottom: 1px solid #ccc;
-    border-top: 1px solid #ccc;
-}

--- a/web/src/app/modules/navigation/modules/project-explorer/components/project-explorer.component.html
+++ b/web/src/app/modules/navigation/modules/project-explorer/components/project-explorer.component.html
@@ -1,9 +1,5 @@
 <div class="input-group input-group-sm">
     <input #searchBox class="form-control form-control-sm" type="search" (keyup)="search(searchBox.value)" />
-    <button *ngIf="searchBox.value"
-        (click)="clearSearch()" title="{{'delete' | translate}}"
-        class="btn btn-sm btn-outline-primary fa fa-remove">
-    </button>
     <div class="input-group-append" title="{{'search' | translate}}">
         <span class="input-group-text">
             <i class="fa fa-search"></i>

--- a/web/src/app/modules/navigation/modules/project-explorer/components/project-explorer.component.ts
+++ b/web/src/app/modules/navigation/modules/project-explorer/components/project-explorer.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
@@ -126,13 +126,6 @@ export class ProjectExplorer implements OnInit {
         this._rootLibraries = undefined;
         this.searchQueries = undefined;
         this.searchResults = undefined;
-    }
-
-
-    @ViewChild('searchBox') searchBox: ElementRef;
-
-    clearSearch() {
-        this.searchBox.nativeElement.value = null;
     }
 
     public get projectName(): string {


### PR DESCRIPTION
[trello](https://trello.com/c/sCUGaOew/399-zwei-buttons-f%C3%BCrs-l%C3%B6schen-der-sucheingabe)

The Angular update seems to provide this option anyway.

I reverted a previous commit, where I added this option to delete the search input.