### PR TITLE
Save language correctly in cookie

### DIFF
--- a/web/src/app/modules/common/modules/i18n/components/language-chooser.component.ts
+++ b/web/src/app/modules/common/modules/i18n/components/language-chooser.component.ts
@@ -52,7 +52,7 @@ export class LanguageChooser implements OnInit {
     public set language(language: string) {
         this.translate.use(language);
         this.setLangAttr(language);
-        this.storeInCookie();
+        this.storeInCookie(language);
     }
 
     public get language(): string {
@@ -71,8 +71,8 @@ export class LanguageChooser implements OnInit {
         return Config.LANGUAGE_CHOOSER_ENABLED;
     }
 
-    private storeInCookie(): void {
-        this.cookie.put(LanguageChooser.LANGUAGE_KEY, this.language);
+    private storeInCookie(language: string): void {
+        this.cookie.put(LanguageChooser.LANGUAGE_KEY, language);
     }
 
     private setLangAttr(language: string): void {


### PR DESCRIPTION
[trello](https://trello.com/c/2INPG6FM/397-spracheeinstellung-wird-nicht-beibehalten)
The language setting was not correctly saved in the cookies. Now, when refreshing the page, the language setting is not lost.