### PR TITLE
New textarea directive for adjusting the height

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "font-awesome": "4.7.0",
     "jquery": "3.3.1",
     "ng2-dragula": "2.1.1",
-    "ngx-textarea-autosize": "2.0.0",
+    "ngx-autosize": "^1.6.0",
     "ngx-cookie": "4.1.2",
     "ngx-translate-core": "11.0.3",
     "ngx-translate-extract": "1.0.0",

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-condition-form.component.html
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-condition-form.component.html
@@ -1,5 +1,5 @@
 <span [formGroup]="formGroup" *ngIf="isInitialized">
     <div class="input-group input-group-sm">
-        <textarea formControlName="condition" type="text" class="form-control form-control-sm" autosize></textarea>
+        <textarea formControlName="condition" type="text" class="form-control-sm" autosize></textarea>
     </div>
 </span>

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-name-form.component.html
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-name-form.component.html
@@ -1,5 +1,5 @@
 <span [formGroup]="formGroup">
     <div class="input-group  input-group-sm">
-        <textarea formControlName="name" type="text" class="form-control form-control-sm" autosize></textarea>
+        <textarea formControlName="name" type="text" class="form-control-sm" autosize></textarea>
     </div>
 </span>

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-parameter-form.component.html
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-parameter-form.component.html
@@ -1,6 +1,6 @@
 <span [formGroup]="formGroup">
     <div class="input-group input-group-sm">
-        <textarea formControlName="name" type="text" class="form-control form-control-sm" autosize></textarea>
+        <textarea formControlName="name" type="text" class="form-control-sm" autosize></textarea>
         <div class="input-group-append">
             <button title="Delete parameter" class="btn btn-sm btn-outline-danger" [class.disabled]="!deleteColumnEnabled" (click)="deleteParameter()"><i class="fa fa-trash"></i></button>
         </div>

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/test-specification-editor.module.ts
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/test-specification-editor.module.ts
@@ -10,7 +10,7 @@ import { TestCaseNameForm } from './components/test-case-name-form.component';
 import { TestCaseRow } from './components/test-case-row.component';
 import { TestParameterForm } from './components/test-parameter-form.component';
 import { TestSpecificationEditor } from './components/test-specification-editor.component';
-import { TextareaAutosizeModule } from 'ngx-textarea-autosize';
+import {AutosizeModule} from 'ngx-autosize';
 
 @NgModule({
   imports: [
@@ -22,7 +22,7 @@ import { TextareaAutosizeModule } from 'ngx-textarea-autosize';
     ReactiveFormsModule,
     SpecmateSharedModule,
     NavigatorModule,
-    TextareaAutosizeModule
+    AutosizeModule
   ],
   declarations: [
     // COMPONENTS IN THIS MODULE


### PR DESCRIPTION
[trello](https://trello.com/c/z6u5KCli/379-eingabefelder-der-testspezifikation-sind-mehrzeilig-und-in-der-gr%C3%B6%C3%9Fe-anpassbar)
Hi @junkerm , I used a different directive, ngx-autosize instead of ngx-textarea-autosize, since this is more up to date. But I had to remove the "form-control" from the textarea because it was interfering with the height somehow. Please check, if this meets the requirements.