### PR TITLE
Error cancel model-generation

### DIFF
--- a/web/src/app/modules/actions/modules/ceg-model-generator-button/components/ceg-model-generator-button.component.ts
+++ b/web/src/app/modules/actions/modules/ceg-model-generator-button/components/ceg-model-generator-button.component.ts
@@ -74,9 +74,7 @@ export class CegModelGeneratorButton {
             await this.dataService.readElement(this.model.url, false);
             await this.dataService.readContents(this.model.url, false);
             this.selectedElementService.select(this.model);
-        } catch (e) {
-            throw e;
-        }
+        } catch (e) {}
     }
 
     public get enabled(): boolean {


### PR DESCRIPTION
[Trello](https://trello.com/c/DKpAcAS2)

Cancel the model generation popup window, should now not lead to an exception any more. 
The throw clause was removed because if the promise is rejected (->cancel is pressed) nothing should happen.