### PR TITLE
Specmate Pattern Config

### DIFF
--- a/bundles/specmate-config/config/specmate-config.properties
+++ b/bundles/specmate-config/config/specmate-config.properties
@@ -71,16 +71,14 @@ session.persistent			= true
 
 
 ## DSL Generation
-# Tries to load the filepath and backs off to the folder and then to the internal files 
-# generation.dsl.DE.folder = ""
-# generation.dsl.DE.rule = ""
-# generation.dsl.DE.dependency = ""
-# generation.dsl.DE.pos = ""
+# Tries to load the filepath and backs off to the internal files 
+# generation.dsl.DE.rule = 
+# generation.dsl.DE.dependency = 
+# generation.dsl.DE.pos = 
 
-# generation.dsl.EN.folder = ""
-# generation.dsl.EN.rule = ""
-# generation.dsl.EN.dependency = ""
-# generation.dsl.EN.pos = ""
+# generation.dsl.EN.rule = 
+# generation.dsl.EN.dependency = ../../../SpecTest/EN/Dep\ EN.spec
+# generation.dsl.EN.pos = 
 
 
 

--- a/bundles/specmate-config/config/specmate-config.properties
+++ b/bundles/specmate-config/config/specmate-config.properties
@@ -69,3 +69,18 @@ session.maxIdleMinutes	 	= 720
 ## Persist sessions in database or keep in memory
 session.persistent			= true
 
+
+## DSL Generation
+# Tries to load the filepath and backs off to the folder and then to the internal files 
+# generation.dsl.DE.folder = ""
+# generation.dsl.DE.rule = ""
+# generation.dsl.DE.dependency = ""
+# generation.dsl.DE.pos = ""
+
+# generation.dsl.EN.folder = ""
+# generation.dsl.EN.rule = ""
+# generation.dsl.EN.dependency = ""
+# generation.dsl.EN.pos = ""
+
+
+

--- a/bundles/specmate-model-generation/src/com/specmate/modelgeneration/GenerateModelFromRequirementService.java
+++ b/bundles/specmate-model-generation/src/com/specmate/modelgeneration/GenerateModelFromRequirementService.java
@@ -11,6 +11,7 @@ import org.osgi.service.log.LogService;
 
 import com.specmate.cause_effect_patterns.resolve.XTextException;
 import com.specmate.common.exception.SpecmateException;
+import com.specmate.config.api.IConfigService;
 import com.specmate.emfrest.api.IRestService;
 import com.specmate.emfrest.api.RestServiceBase;
 import com.specmate.model.requirements.CEGModel;
@@ -32,6 +33,7 @@ public class GenerateModelFromRequirementService extends RestServiceBase {
 
 	INLPService tagger;
 	private LogService logService;
+	private IConfigService configService;
 
 	@Override
 	public String getServiceName() {
@@ -77,7 +79,7 @@ public class GenerateModelFromRequirementService extends RestServiceBase {
 		ELanguage lang = NLPUtil.detectLanguage(text);
 		ICEGFromRequirementGenerator generator;
 		
-		generator = new PatternbasedCEGGenerator(lang, tagger); 
+		generator = new PatternbasedCEGGenerator(lang, tagger, this.configService); 
 		
 		try {
 			generator.createModel(model, text);
@@ -105,5 +107,10 @@ public class GenerateModelFromRequirementService extends RestServiceBase {
 	void setNlptagging(INLPService tagger) {
 		this.tagger = tagger;
 	}
-
+	
+	/** Service reference for config service */
+	@Reference
+	public void setConfigurationService(IConfigService configService) {
+		this.configService = configService;
+	}
 }


### PR DESCRIPTION
Specmate now has the option to specify the location of the CEG Pattern (*.spec) files in the config. Specmate back up to the local files, if no location is specified.